### PR TITLE
Cyclical expense

### DIFF
--- a/src/expenseManager/CyclicalExpense.java
+++ b/src/expenseManager/CyclicalExpense.java
@@ -1,0 +1,53 @@
+package expenseManager;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class CyclicalExpense {
+
+	private Expense expenseTemplate;
+	private Period period;
+	private Date startingDate;
+	private Date lastPaymentDate;
+
+	public CyclicalExpense(Expense newExpense, Period newPeriod, Date newStartingDate) {
+		expenseTemplate = newExpense;
+		period = newPeriod;
+		startingDate = newStartingDate;
+		lastPaymentDate = startingDate;
+	}
+
+	public Expense getExpenseTemplate() {
+		return expenseTemplate;
+	}
+
+	public Period getPeriod() {
+		return period;
+	}
+
+	public Date getStartingDate() {
+		return startingDate;
+	}
+	
+	public Date lastPaymentDate() {
+		return lastPaymentDate;
+	}
+	
+	public boolean isAfterPayDay(Date date) {
+		long diffInMilliseconds = date.getTime() - lastPaymentDate.getTime();
+		long diff = TimeUnit.DAYS.convert(diffInMilliseconds, TimeUnit.MILLISECONDS);
+		return diff >= Period.getPeriodInDays(period);
+	}
+
+	public Expense createPayment() {
+		Expense newExpense = new Expense(expenseTemplate);
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(lastPaymentDate);
+		calendar.add(Calendar.DAY_OF_MONTH, (int) Period.getPeriodInDays(period));
+		newExpense.date = calendar.getTime();
+		lastPaymentDate = newExpense.date;
+		return newExpense;
+	}
+
+}

--- a/src/expenseManager/Expense.java
+++ b/src/expenseManager/Expense.java
@@ -9,8 +9,6 @@ public class Expense {
 	public Date date;
 	public boolean paid;
 	public ArrayList<String> tags;
-	public boolean cyclical;
-	public long monthlyCycle; 
 	
 	public Expense(double newAmount, String newLocation, Date newDate, ArrayList<String> newTags) {
 		amount = newAmount;

--- a/src/expenseManager/Expense.java
+++ b/src/expenseManager/Expense.java
@@ -19,4 +19,11 @@ public class Expense {
 		tags = newTags;
 	}
 	
+	public Expense(Expense newExpense) {
+		amount = newExpense.amount;
+		location = newExpense.location;
+		date = newExpense.date; 
+		tags = newExpense.tags;
+	}
+	
 }

--- a/src/expenseManager/Period.java
+++ b/src/expenseManager/Period.java
@@ -1,0 +1,23 @@
+package expenseManager;
+
+public enum Period {
+	DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, ANNUALY;
+	
+	public static double getPeriodInDays(Period period) {
+		switch(period) {
+		case DAILY:
+			return 1;
+		case WEEKLY:
+			return 7;
+		case BIWEEKLY:
+			return 14;
+		case MONTHLY:
+			return 30.44;
+		case QUARTERLY:
+			return 91.31;
+		case ANNUALY:
+			return 365.24;
+		default: return 0;
+		}
+	}
+}

--- a/test/test/expenseManager/CyclicalExpenseTest.java
+++ b/test/test/expenseManager/CyclicalExpenseTest.java
@@ -1,0 +1,75 @@
+package test.expenseManager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import expenseManager.CyclicalExpense;
+import expenseManager.Expense;
+import expenseManager.Period;
+
+class CyclicalExpenseTest {
+
+	@Test
+	void createCyclicalExpenseTest() {
+		Period period = Period.MONTHLY;
+		Date startingDate = new Date();
+		Expense expenseTemplate = createExpenseTemplate();
+		
+		CyclicalExpense cyclicalExpense = new CyclicalExpense(expenseTemplate, period, startingDate);
+		assertEquals(cyclicalExpense.getExpenseTemplate(), expenseTemplate);
+		assertEquals(cyclicalExpense.getPeriod(), period);
+		assertEquals(cyclicalExpense.getStartingDate(), startingDate);
+		assertEquals(cyclicalExpense.lastPaymentDate(), startingDate);
+	}
+	
+	@Test
+	void shouldPayBeforePeriod() {
+		Period period = Period.MONTHLY;
+		LocalDate date = LocalDate.now().minusDays(15);
+		ZoneId defaultZoneId = ZoneId.systemDefault();
+		Date startingDate = Date.from(date.atStartOfDay(defaultZoneId).toInstant());
+		Expense expenseTemplate = createExpenseTemplate();
+		
+		CyclicalExpense cyclicalExpense = new CyclicalExpense(expenseTemplate, period, startingDate);
+		assertFalse(cyclicalExpense.isAfterPayDay(Calendar.getInstance().getTime()));
+	}
+	
+	@Test
+	void createPaymentTest() {
+		Period period = Period.MONTHLY;
+		Date startingDate = new Date();
+		Expense expenseTemplate = createExpenseTemplate();
+		LocalDate date = LocalDate.now().plusDays(30);
+		ZoneId defaultZoneId = ZoneId.systemDefault();
+		Date nextPaymentDate = Date.from(date.atStartOfDay(defaultZoneId).toInstant());
+
+		CyclicalExpense cyclicalExpense = new CyclicalExpense(expenseTemplate, period, startingDate);
+		Expense expense = cyclicalExpense.createPayment();
+		assertEquals(expenseTemplate.amount, expense.amount);
+		assertEquals(expenseTemplate.location, expense.location);
+		assertEquals(expenseTemplate.tags, expense.tags);
+		assertEquals(0, TimeUnit.DAYS.convert(cyclicalExpense.lastPaymentDate().getTime() - nextPaymentDate.getTime(), TimeUnit.MILLISECONDS));
+		assertEquals(0, TimeUnit.DAYS.convert(expense.date.getTime() - nextPaymentDate.getTime(), TimeUnit.MILLISECONDS));
+	}
+
+	private Expense createExpenseTemplate() {
+		double newAmount = 345.8;
+		String newLocation = "Tokyo";
+		Date today = new Date();
+		ArrayList <String> descriptions = new ArrayList<String>();
+		descriptions.add("Fees");
+		descriptions.add("Electric bill");
+		
+		return new Expense(newAmount, newLocation, today, descriptions);
+	}
+
+}

--- a/test/test/expenseManager/PeriodTest.java
+++ b/test/test/expenseManager/PeriodTest.java
@@ -1,0 +1,20 @@
+package test.expenseManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import expenseManager.Period;
+
+class PeriodTest {
+
+	@Test
+	void getPeriodInDaysTest() {
+		assertEquals(1, Period.getPeriodInDays(Period.DAILY));
+		assertEquals(7, Period.getPeriodInDays(Period.WEEKLY));
+		assertEquals(14, Period.getPeriodInDays(Period.BIWEEKLY));
+		assertEquals(30.44, Period.getPeriodInDays(Period.MONTHLY));
+		assertEquals(91.31, Period.getPeriodInDays(Period.QUARTERLY));
+		assertEquals(365.24, Period.getPeriodInDays(Period.ANNUALY));
+	}
+}


### PR DESCRIPTION
The goal of this pull request is to add the functionality of cyclical expense. 
A cyclical expense can be defined as daily, weekly, biweekly and so on.
The owner of the cyclical expense (account) will trigger every month the createPayment methods that will create a new expense with the proper starting date.  